### PR TITLE
ci: test.ymlのブランチ対象をmasterに修正・PR時に自動テスト実行

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, "**"]
+    branches: [master, main, "**"]
   pull_request:
-    branches: [main]
+    branches: [master, main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

デフォルトブランチが `master` であるにも関わらず、既存の `test.yml` が `main` ブランチのみを対象にしていた。これによりPR作成時のCIチェックが正常に動作していなかった。

## Changes

- `.github/workflows/test.yml`: `push` / `pull_request` のブランチ対象に `master` を追加
  - Before: `branches: [main, "**"]` / `branches: [main]`
  - After: `branches: [master, main, "**"]` / `branches: [master, main]`

## Testing

- このPR自体のCIが `master` ブランチ向けのPRとして正しく実行されることで検証

Fixes eisei-komiya/econ-cal-sync#16