### PR TITLE
fix: upsert_event のAPIエラーを握りつぶさず failed を返すように修正 (#19)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -169,21 +169,30 @@ def get_existing_events(
 def upsert_event(
     service, calendar_id: str, gcal_event: dict, existing: dict[str, str],
 ) -> str:
-    """Create or update a Google Calendar event.  Returns ``'created'`` or ``'updated'``."""
+    """Create or update a Google Calendar event.
+
+    Returns ``'created'``, ``'updated'``, or ``'failed'``.  On API error the
+    exception is logged and ``'failed'`` is returned so that the caller can
+    continue processing the remaining events instead of aborting the entire run.
+    """
     eid = gcal_event["extendedProperties"]["private"][_EXT_PROP_KEY]
-    if eid in existing:
-        service.events().update(
-            calendarId=calendar_id,
-            eventId=existing[eid],
-            body=gcal_event,
-        ).execute()
-        return "updated"
-    else:
-        service.events().insert(
-            calendarId=calendar_id,
-            body=gcal_event,
-        ).execute()
-        return "created"
+    try:
+        if eid in existing:
+            service.events().update(
+                calendarId=calendar_id,
+                eventId=existing[eid],
+                body=gcal_event,
+            ).execute()
+            return "updated"
+        else:
+            service.events().insert(
+                calendarId=calendar_id,
+                body=gcal_event,
+            ).execute()
+            return "created"
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [failed] {gcal_event.get('summary', eid)}: {exc}")
+        return "failed"
 
 
 # ---------------------------------------------------------------------------
@@ -224,17 +233,25 @@ def main() -> None:
     existing = get_existing_events(service, calendar_id, date_from, date_to)
     print(f"Found {len(existing)} existing events in Google Calendar.")
 
-    created = updated = 0
+    created = updated = failed = 0
     for ev in events:
         gcal_event = build_gcal_event(ev, owner_email=owner_email)
         action = upsert_event(service, calendar_id, gcal_event, existing)
         if action == "created":
             created += 1
-        else:
+        elif action == "updated":
             updated += 1
-        print(f"  [{action}] {gcal_event['summary']}")
+        else:
+            failed += 1
+        if action != "failed":
+            print(f"  [{action}] {gcal_event['summary']}")
 
-    print(f"Done. Created: {created}, Updated: {updated}")
+    print(f"Done. Created: {created}, Updated: {updated}, Failed: {failed}")
+    if failed:
+        raise RuntimeError(
+            f"{failed} event(s) could not be upserted. "
+            "Check the logs above for details."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -365,3 +365,64 @@ class TestReminders:
             r["minutes"] for r in gcal["reminders"]["overrides"] if r["method"] == "popup"
         }
         assert popup_minutes == set(REMINDER_MINUTES)
+
+
+class TestUpsertEvent:
+    """Tests for upsert_event error handling."""
+
+    def _make_gcal_event(self, eid: str = "test_event_id") -> dict:
+        return {
+            "summary": "Test Event",
+            "extendedProperties": {"private": {"econ_event_id": eid}},
+        }
+
+    def test_upsert_creates_new_event(self) -> None:
+        """When the event id is not in existing, insert is called."""
+        from src.sync import upsert_event
+        service = MagicMock()
+
+        result = upsert_event(service, "cal_id", self._make_gcal_event(), existing={})
+
+        assert result == "created"
+        service.events().insert.assert_called_once_with(
+            calendarId="cal_id",
+            body=self._make_gcal_event(),
+        )
+
+    def test_upsert_updates_existing_event(self) -> None:
+        """When the event id is in existing, update is called."""
+        from src.sync import upsert_event
+        service = MagicMock()
+
+        result = upsert_event(
+            service, "cal_id", self._make_gcal_event(), existing={"test_event_id": "gcal_123"}
+        )
+
+        assert result == "updated"
+        service.events().update.assert_called_once_with(
+            calendarId="cal_id",
+            eventId="gcal_123",
+            body=self._make_gcal_event(),
+        )
+
+    def test_upsert_returns_failed_on_api_error(self) -> None:
+        """When the API call raises an exception, 'failed' is returned (not re-raised)."""
+        from src.sync import upsert_event
+        service = MagicMock()
+        service.events().insert().execute.side_effect = Exception("API quota exceeded")
+
+        result = upsert_event(service, "cal_id", self._make_gcal_event(), existing={})
+
+        assert result == "failed"
+
+    def test_upsert_update_returns_failed_on_api_error(self) -> None:
+        """When update raises, 'failed' is returned without re-raising."""
+        from src.sync import upsert_event
+        service = MagicMock()
+        service.events().update().execute.side_effect = RuntimeError("503 Service Unavailable")
+
+        result = upsert_event(
+            service, "cal_id", self._make_gcal_event(), existing={"test_event_id": "gcal_123"}
+        )
+
+        assert result == "failed"


### PR DESCRIPTION
## 変更内容

`upsert_event()` の Google Calendar API 呼び出し（`insert` / `update`）を `try/except` で囲み、API エラー発生時に例外を再スローせず `failed` を返すように修正しました。これにより、1件のイベント同期失敗で残り全件の処理が中断される問題を解消しています。

### 変更点

**`src/sync.py`**
- `upsert_event`: `try/except Exception` を追加。例外発生時はエラーをログ出力して `failed` を返す
- `main`: `failed` カウンターを追加。`failed > 0` の場合は最後に `RuntimeError` を raise して終了コードを非ゼロにし、GitHub Actions で検知可能にする

**`tests/test_sync.py`**
- `TestUpsertEvent` クラスを追加（4件）
  - 新規作成: `insert` が呼ばれ `created` が返ること
  - 更新: `update` が呼ばれ `updated` が返ること
  - insert 時のエラー: `failed` が返り例外が伝播しないこと
  - update 時のエラー: `failed` が返り例外が伝播しないこと

## 検証方法

```bash
uv run --frozen --extra dev pytest tests/ -v
```

全 25 件通過を確認済み。

## エッジケース

- `failed` カウントが 1 以上の場合は `RuntimeError` を raise するため、GitHub Actions のワークフローは失敗としてマークされる
- 一部イベントの失敗は次回の同期実行時に再試行される（冪等性は `extendedProperties` で保証済み）
- Rate limit (429) 等のリトライが必要なエラーは別 Issue で扱う予定

Fixes #19