### PR TITLE
fix: get_existing_events のページネーション中のAPIエラーを処理 (#21)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -140,17 +140,22 @@ def get_existing_events(
     page_token = None
 
     while True:
-        result = (
-            service.events()
-            .list(
-                calendarId=calendar_id,
-                timeMin=time_min,
-                timeMax=time_max,
-                singleEvents=True,
-                pageToken=page_token,
+        try:
+            result = (
+                service.events()
+                .list(
+                    calendarId=calendar_id,
+                    timeMin=time_min,
+                    timeMax=time_max,
+                    singleEvents=True,
+                    pageToken=page_token,
+                )
+                .execute()
             )
-            .execute()
-        )
+        except Exception as exc:  # noqa: BLE001
+            print(f"[get_existing_events] API error: {exc}")
+            break  # 取得済み分だけで続行（重複作成を最小限に抑える）
+
         for item in result.get("items", []):
             eid = (
                 item.get("extendedProperties", {})

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -426,3 +426,104 @@ class TestUpsertEvent:
         )
 
         assert result == "failed"
+
+
+class TestGetExistingEvents:
+    """Tests for get_existing_events error handling and pagination."""
+
+    _EXT_KEY = "econ_event_id"
+
+    def _make_item(self, eid: str, gcal_id: str) -> dict:
+        return {
+            "id": gcal_id,
+            "extendedProperties": {"private": {self._EXT_KEY: eid}},
+        }
+
+    def _make_service(self, pages: list[list[dict]], error_on_page: int | None = None) -> MagicMock:
+        """Build a mock service that returns paginated results.
+
+        If error_on_page is set, the call for that page index (0-based) raises an exception.
+        """
+        service = MagicMock()
+        responses = []
+        for i, items in enumerate(pages):
+            if error_on_page is not None and i == error_on_page:
+                responses.append(Exception(f"API error on page {i}"))
+            else:
+                next_token = f"token_{i+1}" if i < len(pages) - 1 else None
+                resp = {"items": items}
+                if next_token:
+                    resp["nextPageToken"] = next_token
+                responses.append(resp)
+
+        call_count = {"n": 0}
+        original_execute = service.events().list().execute
+
+        def side_effect_execute(*args, **kwargs):
+            n = call_count["n"]
+            call_count["n"] += 1
+            r = responses[n]
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        service.events().list().execute.side_effect = side_effect_execute
+        return service
+
+    def test_single_page_returns_mapping(self) -> None:
+        """Single page with two events → both are in the mapping."""
+        from src.sync import get_existing_events
+
+        items = [self._make_item("ev1", "gcal1"), self._make_item("ev2", "gcal2")]
+        service = self._make_service([items])
+
+        result = get_existing_events(service, "cal_id", "2026-01-01", "2026-01-31")
+
+        assert result == {"ev1": "gcal1", "ev2": "gcal2"}
+
+    def test_multiple_pages_returns_all_events(self) -> None:
+        """Multi-page response → events from all pages are collected."""
+        from src.sync import get_existing_events
+
+        page1 = [self._make_item("ev1", "gcal1")]
+        page2 = [self._make_item("ev2", "gcal2")]
+        service = self._make_service([page1, page2])
+
+        result = get_existing_events(service, "cal_id", "2026-01-01", "2026-01-31")
+
+        assert result == {"ev1": "gcal1", "ev2": "gcal2"}
+
+    def test_api_error_on_first_page_returns_empty(self) -> None:
+        """API error on the first page → returns empty dict without raising."""
+        from src.sync import get_existing_events
+
+        service = self._make_service([[], []], error_on_page=0)
+
+        result = get_existing_events(service, "cal_id", "2026-01-01", "2026-01-31")
+
+        assert result == {}
+
+    def test_api_error_on_second_page_returns_partial(self) -> None:
+        """API error mid-pagination → returns whatever was collected before the error."""
+        from src.sync import get_existing_events
+
+        page1 = [self._make_item("ev1", "gcal1")]
+        service = self._make_service([page1, []], error_on_page=1)
+
+        result = get_existing_events(service, "cal_id", "2026-01-01", "2026-01-31")
+
+        assert result == {"ev1": "gcal1"}
+
+    def test_items_without_ext_prop_are_ignored(self) -> None:
+        """Events missing the extendedProperties key are silently skipped."""
+        from src.sync import get_existing_events
+
+        items = [
+            {"id": "gcal1"},  # no extendedProperties at all
+            self._make_item("ev2", "gcal2"),
+        ]
+        service = self._make_service([items])
+
+        result = get_existing_events(service, "cal_id", "2026-01-01", "2026-01-31")
+
+        assert result == {"ev2": "gcal2"}


### PR DESCRIPTION
## 概要

Issue #21 の対応です。

`get_existing_events()` のページネーションループ内で `service.events().list().execute()` がAPIエラー（ネットワーク障害・認証切れ・Quota超過など）を投げた場合、例外がそのまま `main()` に伝播してプログラム全体がクラッシュするバグを修正します。

## 変更内容

### `src/sync.py`
- `get_existing_events()` のページネーションループに `try/except Exception` を追加
- APIエラー発生時はエラーメッセージを出力してループを `break`（それまでに取得済みの mapping を返す）
- `# noqa: BLE001` を付与し、意図的な broad except であることを明示

### `tests/test_sync.py`
- `TestGetExistingEvents` クラスを追加（5ケース）
  - 1ページのみ → 全イベントが mapping に含まれる
  - 複数ページ → 全ページのイベントが収集される
  - 1ページ目でエラー → 空の dict を返す（例外は投げない）
  - 2ページ目でエラー → 1ページ目分だけ返す（部分的収集）
  - `extendedProperties` なし → 該当イベントをスキップ

## 検証方法

```bash
uv run pytest tests/ -v
```

全 30 テストがパスすることを確認済み。

## エッジケースの考慮

- **ページ途中でエラー** → 取得済み分を返すことで「重複作成」を最小限に抑える
- **1ページ目でエラー** → 空の mapping を返す（全イベントが新規として `upsert_event` に渡るが、`upsert_event` 側の `try/except` で吸収される）
- より保守的な設計（エラー時に `raise` してシンクを中断）も検討したが、Issue #21 の修正案に従い「続行して取得済み分で処理」を採用

Closes #21