### PR TITLE
fix: FF JSON スキーマ変更時の警告バリデーションを追加 (#26)

### DIFF
--- a/src/fetchers/forexfactory.py
+++ b/src/fetchers/forexfactory.py
@@ -26,6 +26,12 @@ _IMPACT_MAP: dict[str, int] = {
     "high": 3,
 }
 
+# Required keys expected in each FF JSON event dict.
+_FF_JSON_REQUIRED_KEYS: frozenset[str] = frozenset({"title", "date", "country", "impact"})
+
+# If this fraction or more of sampled events are missing required keys, emit a warning.
+_FF_JSON_SCHEMA_WARN_THRESHOLD: float = 0.5
+
 
 class ForexFactoryFetcher(BaseFetcher):
     """Fetch economic calendar data from ForexFactory."""
@@ -86,6 +92,43 @@ class ForexFactoryFetcher(BaseFetcher):
     # ------------------------------------------------------------------ #
 
     @staticmethod
+    def _validate_ff_json_schema(data: list[dict], *, sample_size: int = 5) -> None:
+        """Warn if the FF JSON schema appears to have changed.
+
+        Samples the first *sample_size* events and checks whether each contains
+        all required keys (``title``, ``date``, ``country``, ``impact``).
+        If at least :data:`_FF_JSON_SCHEMA_WARN_THRESHOLD` of the sample is
+        missing one or more keys, a warning is printed so that operators are
+        alerted to a potential upstream schema change before events are
+        silently dropped.
+
+        This is a best-effort check and does **not** raise; callers must not
+        rely on it for control flow.
+        """
+        if not data:
+            return
+        sample = [ev for ev in data[:sample_size] if isinstance(ev, dict)]
+        if not sample:
+            print(
+                "[forexfactory] Warning: FF JSON contains non-dict entries; "
+                "schema may have changed."
+            )
+            return
+        missing_counts = sum(
+            1 for ev in sample if not _FF_JSON_REQUIRED_KEYS.issubset(ev.keys())
+        )
+        if missing_counts / len(sample) >= _FF_JSON_SCHEMA_WARN_THRESHOLD:
+            # Collect the union of all missing keys across the sample for diagnostics.
+            missing_keys: set[str] = set()
+            for ev in sample:
+                missing_keys |= _FF_JSON_REQUIRED_KEYS - ev.keys()
+            print(
+                f"[forexfactory] Warning: FF JSON schema may have changed. "
+                f"Missing keys in {missing_counts}/{len(sample)} sampled events: "
+                f"{sorted(missing_keys)}"
+            )
+
+    @staticmethod
     def _fetch_ff_json() -> list[dict]:
         """Download the official FF this-week JSON."""
         try:
@@ -98,7 +141,10 @@ class ForexFactoryFetcher(BaseFetcher):
             )
             with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
                 data = json.loads(resp.read())
-            return data if isinstance(data, list) else []
+            if not isinstance(data, list):
+                return []
+            ForexFactoryFetcher._validate_ff_json_schema(data)
+            return data
         except Exception as exc:  # noqa: BLE001
             print(f"[forexfactory] FF JSON fetch failed: {exc}")
             return []

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -527,3 +527,86 @@ class TestGetExistingEvents:
         result = get_existing_events(service, "cal_id", "2026-01-01", "2026-01-31")
 
         assert result == {"ev2": "gcal2"}
+
+
+class TestValidateFFJsonSchema:
+    """Tests for ForexFactoryFetcher._validate_ff_json_schema."""
+
+    def test_no_warning_when_data_is_empty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Empty list → no output."""
+        ForexFactoryFetcher._validate_ff_json_schema([])
+        assert capsys.readouterr().out == ""
+
+    def test_no_warning_when_all_required_keys_present(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """All events have required keys → no warning."""
+        data = [
+            {"title": "CPI", "date": "2026-01-01", "country": "USD", "impact": "High"},
+            {"title": "NFP", "date": "2026-01-02", "country": "USD", "impact": "High"},
+        ]
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        assert capsys.readouterr().out == ""
+
+    def test_warning_when_all_events_missing_keys(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """All sampled events missing required keys → warning is printed."""
+        data = [{"foo": "bar"}, {"baz": "qux"}]
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "FF JSON schema may have changed" in out
+
+    def test_warning_includes_missing_key_names(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Warning message lists the specific missing key names."""
+        data = [{"foo": "bar"}]  # all required keys absent
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        out = capsys.readouterr().out
+        for key in ("title", "date", "country", "impact"):
+            assert key in out
+
+    def test_no_warning_below_threshold(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Only 1 of 4 events missing keys → below 50% threshold, no warning."""
+        valid = {"title": "CPI", "date": "2026-01-01", "country": "USD", "impact": "High"}
+        data = [valid, valid, valid, {"foo": "bar"}]
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        assert capsys.readouterr().out == ""
+
+    def test_warning_exactly_at_threshold(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Exactly 50% missing → warning is emitted (>= threshold)."""
+        valid = {"title": "CPI", "date": "2026-01-01", "country": "USD", "impact": "High"}
+        data = [valid, {"foo": "bar"}]  # 1/2 = 50%
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        assert "Warning" in capsys.readouterr().out
+
+    def test_non_dict_entries_emit_different_warning(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-dict entries (e.g. strings) in data → schema-change warning."""
+        data = ["not a dict", 42, None]  # type: ignore[list-item]
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        assert "Warning" in capsys.readouterr().out
+
+    def test_fetch_ff_json_calls_validate_on_success(self) -> None:
+        """_fetch_ff_json() calls _validate_ff_json_schema() when data is a list."""
+        data = [{"title": "CPI", "date": "2026-01-01", "country": "USD", "impact": "High"}]
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_response),
+            patch.object(ForexFactoryFetcher, "_validate_ff_json_schema") as mock_validate,
+        ):
+            result = ForexFactoryFetcher._fetch_ff_json()
+
+        mock_validate.assert_called_once_with(data)
+        assert result == data
+
+    def test_fetch_ff_json_returns_empty_on_non_list_response(self) -> None:
+        """_fetch_ff_json() returns [] when JSON root is not a list."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"error": "bad"}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = ForexFactoryFetcher._fetch_ff_json()
+
+        assert result == []


### PR DESCRIPTION
## 概要

Issue #26 の対応。`ForexFactoryFetcher._fetch_ff_json()` がフィールド欠損に気づけない問題を修正。

## 変更内容

### `src/fetchers/forexfactory.py`

- `_FF_JSON_REQUIRED_KEYS` 定数を追加（`title`, `date`, `country`, `impact`）
- `_FF_JSON_SCHEMA_WARN_THRESHOLD` 定数を追加（50% = `0.5`）
- `_validate_ff_json_schema()` 静的メソッドを新規追加
  - 最初の5件をサンプリングして必須キーの存在を確認
  - サンプルの50%以上が必須キーを欠いている場合、欠けているキー名と共に警告を `print`
  - non-dict エントリが含まれる場合も別途警告
- `_fetch_ff_json()` がリストを受け取った場合に `_validate_ff_json_schema()` を呼ぶよう更新

### `tests/test_sync.py`

`TestValidateFFJsonSchema` クラスを追加（9テスト）:

| テスト | 内容 |
|---|---|
| `test_no_warning_when_data_is_empty` | 空リスト → 出力なし |
| `test_no_warning_when_all_required_keys_present` | 全キーあり → 警告なし |
| `test_warning_when_all_events_missing_keys` | 全件欠損 → 警告あり |
| `test_warning_includes_missing_key_names` | 警告にキー名が含まれる |
| `test_no_warning_below_threshold` | 1/4 欠損 → 50%未満 → 警告なし |
| `test_warning_exactly_at_threshold` | 1/2 欠損 → ちょうど50% → 警告あり |
| `test_non_dict_entries_emit_different_warning` | non-dict エントリ → 警告あり |
| `test_fetch_ff_json_calls_validate_on_success` | `_fetch_ff_json` が `_validate` を呼ぶ |
| `test_fetch_ff_json_returns_empty_on_non_list_response` | 非list JSON → 空を返す |

## 検証方法

```bash
uv run --with pytest pytest tests/test_sync.py::TestValidateFFJsonSchema -v
# → 9 passed

uv run --with pytest pytest tests/ -v
# → 39 passed
```

## エッジケース

- **警告は例外を投げない**: バリデーション失敗はあくまでソフトウォーニング。既存の `fetch()` ロジックはそのまま動作し続ける
- **サンプリング上限**: 最初の5件のみ検査。巨大なレスポンスでも軽量
- **しきい値 50%**: 単一イベントが偶然フィールドを欠く場合（例: ホリデーイベント）で誤検知しないよう余裕を持たせている
- **non-dict エントリ**: FF JSONが配列内に文字列等を含む場合も別経路で検出

Closes #26