### PR TITLE
fix: FMPFetcher のID衝突を修正 - CCYをIDに追加し連番サフィックスで重複排除 (#28)

### DIFF
--- a/src/fetchers/fmp.py
+++ b/src/fetchers/fmp.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.request
+from dataclasses import replace
 from datetime import datetime, timezone
 
 from ..models import EconomicEvent
@@ -75,6 +76,7 @@ class FMPFetcher(BaseFetcher):
             return []
 
         results: list[EconomicEvent] = []
+        seen_ids: dict[str, int] = {}
         for raw in data:
             ccy = _COUNTRY_TO_CCY.get((raw.get("country") or "").upper(), "")
             if ccy not in countries:
@@ -85,7 +87,15 @@ class FMPFetcher(BaseFetcher):
             dt = self._parse_date(raw.get("date") or "")
             if dt is None:
                 continue
-            results.append(self._normalise(raw, dt, ccy))
+            event = self._normalise(raw, dt, ccy)
+            base_id = event.id
+            if base_id in seen_ids:
+                seen_ids[base_id] += 1
+                # Replace the id field with a suffixed version to avoid collision.
+                event = replace(event, id=f"{base_id}_{seen_ids[base_id]}")
+            else:
+                seen_ids[base_id] = 0
+            results.append(event)
 
         return results
 
@@ -108,7 +118,7 @@ class FMPFetcher(BaseFetcher):
     @staticmethod
     def _normalise(raw: dict, dt_utc: datetime, ccy: str) -> EconomicEvent:
         event_name = (raw.get("event") or "Economic Event").strip()
-        eid = f"fmp_{event_name}_{dt_utc.strftime('%Y%m%dT%H%M%S')}"
+        eid = f"fmp_{ccy}_{event_name}_{dt_utc.strftime('%Y%m%dT%H%M%S')}"
         return EconomicEvent(
             id=eid,
             name=event_name,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -610,3 +610,44 @@ class TestValidateFFJsonSchema:
             result = ForexFactoryFetcher._fetch_ff_json()
 
         assert result == []
+
+
+class TestFMPFetcherNormalise:
+    """Tests for FMPFetcher._normalise and ID collision handling."""
+
+    def test_normalise_id_includes_ccy(self) -> None:
+        """ID should include the currency code to distinguish same-name events."""
+        from src.fetchers.fmp import FMPFetcher
+
+        raw = {"event": "CPI", "country": "US", "impact": "High", "date": "2026-01-01T12:00:00"}
+        dt = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        event = FMPFetcher._normalise(raw, dt, "USD")
+        assert "USD" in event.id
+        assert event.id == "fmp_USD_CPI_20260101T120000"
+
+    def test_fetch_deduplicates_ids_with_suffix(self) -> None:
+        """Duplicate IDs within same fetch → suffixed with _1, _2, etc."""
+        from src.fetchers.fmp import FMPFetcher
+
+        # Two events: same name, same time, same country
+        data = [
+            {"event": "CPI", "country": "US", "impact": "high", "date": "2026-01-01T12:00:00"},
+            {"event": "CPI", "country": "US", "impact": "high", "date": "2026-01-01T12:00:00"},
+        ]
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("urllib.request.urlopen", return_value=mock_response),
+            patch.dict("os.environ", {"FMP_API_KEY": "test_key"}),
+        ):
+            fetcher = FMPFetcher()
+            results = fetcher.fetch("2026-01-01", "2026-01-07", countries={"USD"}, importance_min=1)
+
+        assert len(results) == 2
+        ids = [e.id for e in results]
+        assert len(set(ids)) == 2, f"IDs should be unique, got: {ids}"
+        assert ids[0] == "fmp_USD_CPI_20260101T120000"
+        assert ids[1] == "fmp_USD_CPI_20260101T120000_1"


### PR DESCRIPTION
## 変更内容

### 問題
`_normalise()` が生成するIDが `fmp_{event_name}_{timestamp}` だったため、同一時刻に同名イベントが複数存在すると（または通貨が異なる同名イベント）IDが衝突し、後続の Google Calendar sync でイベントが上書き・消失しうる問題があった。

### 修正
1. **`_normalise()`**: IDに通貨コード (`ccy`) を追加 → `fmp_{ccy}_{event_name}_{timestamp}` の形式に変更。異なる通貨の同名同時刻イベントを区別できる。
2. **`fetch()`**: 同一フェッチ内でID衝突を検出し、2件目以降に `_1`, `_2` などの連番サフィックスを付与。完全に同一なイベントが複数ある場合も一意性を保証。

## 検証方法

```bash
uv run --extra dev python -m pytest tests/test_sync.py::TestFMPFetcherNormalise -v
```

新規テスト2件:
- `test_normalise_id_includes_ccy`: IDに通貨コードが含まれることを検証
- `test_fetch_deduplicates_ids_with_suffix`: 重複ID発生時に連番サフィックスで一意化されることを検証

## 考慮したエッジケース

- 異なる通貨の同名イベント（例: EU と US で同じ名前）→ CCY追加で解決
- 完全に重複するエントリ（APIのバグ等）→ 連番サフィックスで解決
- 既存のGoogle Calendarイベントとの互換性: IDフォーマットが変わるため初回実行時に既存イベントが重複作成される可能性があるが、これはバグ修正として許容範囲

Closes #28