### PR TITLE
fix: 必須環境変数が未設定時に KeyError でなく明示的な RuntimeError を送出 (#32)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -57,7 +57,12 @@ SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 def build_calendar_service():
     """Return an authenticated Google Calendar service using a service account."""
-    sa_json = os.environ["GOOGLE_SA_JSON"]
+    sa_json = os.environ.get("GOOGLE_SA_JSON")
+    if not sa_json:
+        raise RuntimeError(
+            "GOOGLE_SA_JSON environment variable is not set. "
+            "Set it to the service account JSON content."
+        )
     sa_info = json.loads(sa_json)
     credentials = service_account.Credentials.from_service_account_info(
         sa_info, scopes=SCOPES,
@@ -205,7 +210,12 @@ def upsert_event(
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    calendar_id = os.environ["GOOGLE_CALENDAR_ID"]
+    calendar_id = os.environ.get("GOOGLE_CALENDAR_ID")
+    if not calendar_id:
+        raise RuntimeError(
+            "GOOGLE_CALENDAR_ID environment variable is not set. "
+            "Set it to the target Google Calendar ID."
+        )
     source_name = os.environ.get("EVENT_SOURCE", "forexfactory")
     # Optional: calendar owner email for attendee-based reminder delivery.
     # Service-account-created events only fire reminders for the service account

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -651,3 +651,28 @@ class TestFMPFetcherNormalise:
         assert len(set(ids)) == 2, f"IDs should be unique, got: {ids}"
         assert ids[0] == "fmp_USD_CPI_20260101T120000"
         assert ids[1] == "fmp_USD_CPI_20260101T120000_1"
+
+
+class TestEnvVarValidation:
+    """Tests for explicit error messages when required env vars are missing."""
+
+    def test_build_calendar_service_raises_on_missing_sa_json(self) -> None:
+        """build_calendar_service should raise RuntimeError with helpful message."""
+        import os
+        from src.sync import build_calendar_service
+
+        env = {k: v for k, v in os.environ.items() if k != "GOOGLE_SA_JSON"}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(RuntimeError, match="GOOGLE_SA_JSON"):
+                build_calendar_service()
+
+    def test_main_raises_on_missing_calendar_id(self) -> None:
+        """main() should raise RuntimeError with helpful message when GOOGLE_CALENDAR_ID is absent."""
+        import os
+        from src.sync import main
+
+        env = {k: v for k, v in os.environ.items() if k != "GOOGLE_CALENDAR_ID"}
+        env["GOOGLE_SA_JSON"] = "{}"  # prevent SA_JSON error first
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(RuntimeError, match="GOOGLE_CALENDAR_ID"):
+                main()


### PR DESCRIPTION
## 概要

Fixes #32

`GOOGLE_SA_JSON` や `GOOGLE_CALENDAR_ID` が未設定の場合、従来は `KeyError` が発生していた。これを明示的な `RuntimeError` に変更し、ユーザーが何を設定すべきかすぐに分かるメッセージを添える。

## 変更内容

- `build_calendar_service()`: `os.environ["GOOGLE_SA_JSON"]` → `os.environ.get()` + `RuntimeError`
- `main()`: `os.environ["GOOGLE_CALENDAR_ID"]` → `os.environ.get()` + `RuntimeError`

## 検証方法

```bash
uv run pytest tests/test_sync.py::TestEnvVarValidation -v
```

## エッジケース

- 空文字列 (`GOOGLE_SA_JSON=""`) も「未設定」として扱われる (`not sa_json` で検出)
- `GOOGLE_SA_JSON` が不正な JSON の場合は既存の `json.loads` エラーがそのまま伝播する（本PRのスコープ外）
