### PR TITLE
fix: Google Calendar API呼び出しにリトライ・バックオフ処理を追加 (#35)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from datetime import datetime, timedelta, timezone
 
 from google.oauth2 import service_account
@@ -49,6 +50,38 @@ _IMPORTANCE_STARS: dict[int, str] = {
 _EXT_PROP_KEY = "econ_event_id"
 
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
+
+# ---------------------------------------------------------------------------
+# Retry / back-off helper
+# ---------------------------------------------------------------------------
+
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+_MAX_RETRIES = 4
+_BACKOFF_BASE = 2.0  # seconds
+
+
+def _call_with_retry(request_callable, *, max_retries: int = _MAX_RETRIES) -> dict:
+    """Execute a Google API request with exponential back-off on transient errors.
+
+    ``request_callable`` must be a zero-argument callable that invokes
+    ``<resource>.execute()`` and returns the response dict.
+
+    Raises the last exception when all retries are exhausted.
+    """
+    import googleapiclient.errors  # local import to keep top-level imports clean
+
+    for attempt in range(max_retries + 1):
+        try:
+            return request_callable()
+        except googleapiclient.errors.HttpError as exc:
+            status = exc.status_code if hasattr(exc, "status_code") else exc.resp.status
+            if status not in _RETRYABLE_STATUS_CODES or attempt == max_retries:
+                raise
+            wait = _BACKOFF_BASE ** attempt
+            print(f"  [retry] HTTP {status}, waiting {wait:.0f}s (attempt {attempt + 1}/{max_retries})")
+            time.sleep(wait)
+        except Exception:
+            raise  # non-HTTP errors are not retried
 
 
 # ---------------------------------------------------------------------------
@@ -146,19 +179,19 @@ def get_existing_events(
 
     while True:
         try:
-            result = (
-                service.events()
+            result = _call_with_retry(
+                lambda pt=page_token: service.events()
                 .list(
                     calendarId=calendar_id,
                     timeMin=time_min,
                     timeMax=time_max,
                     singleEvents=True,
-                    pageToken=page_token,
+                    pageToken=pt,
                 )
                 .execute()
             )
         except Exception as exc:  # noqa: BLE001
-            print(f"[get_existing_events] API error: {exc}")
+            print(f"[get_existing_events] API error after retries: {exc}")
             break  # 取得済み分だけで続行（重複作成を最小限に抑える）
 
         for item in result.get("items", []):
@@ -188,17 +221,21 @@ def upsert_event(
     eid = gcal_event["extendedProperties"]["private"][_EXT_PROP_KEY]
     try:
         if eid in existing:
-            service.events().update(
-                calendarId=calendar_id,
-                eventId=existing[eid],
-                body=gcal_event,
-            ).execute()
+            _call_with_retry(
+                lambda: service.events().update(
+                    calendarId=calendar_id,
+                    eventId=existing[eid],
+                    body=gcal_event,
+                ).execute()
+            )
             return "updated"
         else:
-            service.events().insert(
-                calendarId=calendar_id,
-                body=gcal_event,
-            ).execute()
+            _call_with_retry(
+                lambda: service.events().insert(
+                    calendarId=calendar_id,
+                    body=gcal_event,
+                ).execute()
+            )
             return "created"
     except Exception as exc:  # noqa: BLE001
         print(f"  [failed] {gcal_event.get('summary', eid)}: {exc}")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -676,3 +676,80 @@ class TestEnvVarValidation:
         with patch.dict("os.environ", env, clear=True):
             with pytest.raises(RuntimeError, match="GOOGLE_CALENDAR_ID"):
                 main()
+
+
+class TestCallWithRetry:
+    """Tests for the _call_with_retry helper."""
+
+    def test_succeeds_on_first_attempt(self) -> None:
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def success():
+            nonlocal call_count
+            call_count += 1
+            return {"ok": True}
+
+        result = _call_with_retry(success)
+        assert result == {"ok": True}
+        assert call_count == 1
+
+    def test_retries_on_429_then_succeeds(self) -> None:
+        """Should retry on 429 and eventually succeed."""
+        import googleapiclient.errors
+        from unittest.mock import MagicMock
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                resp = MagicMock()
+                resp.status = 429
+                raise googleapiclient.errors.HttpError(resp=resp, content=b"rate limited")
+            return {"ok": True}
+
+        with patch("time.sleep"):  # don't actually sleep in tests
+            result = _call_with_retry(flaky, max_retries=4)
+
+        assert result == {"ok": True}
+        assert call_count == 3
+
+    def test_raises_after_max_retries_exhausted(self) -> None:
+        """Should raise the last exception when retries are exhausted."""
+        import googleapiclient.errors
+        from unittest.mock import MagicMock
+        from src.sync import _call_with_retry
+
+        resp = MagicMock()
+        resp.status = 503
+
+        def always_fails():
+            raise googleapiclient.errors.HttpError(resp=resp, content=b"unavailable")
+
+        with patch("time.sleep"):
+            with pytest.raises(googleapiclient.errors.HttpError):
+                _call_with_retry(always_fails, max_retries=2)
+
+    def test_does_not_retry_on_non_retryable_status(self) -> None:
+        """Should not retry on 4xx errors that are not in the retryable set."""
+        import googleapiclient.errors
+        from unittest.mock import MagicMock
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def not_found():
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.status = 404
+            raise googleapiclient.errors.HttpError(resp=resp, content=b"not found")
+
+        with pytest.raises(googleapiclient.errors.HttpError):
+            _call_with_retry(not_found, max_retries=3)
+
+        assert call_count == 1  # no retry


### PR DESCRIPTION
## 概要

Issue #35 の対応。Google Calendar API の呼び出しに指数バックオフ付きリトライを追加。

## 変更内容

- `_call_with_retry()` ヘルパー関数を追加
  - 429 (Rate Limit), 500, 502, 503, 504 をリトライ対象とする
  - デフォルト最大4回リトライ、待機時間は `2^attempt` 秒（1秒, 2秒, 4秒, 8秒）
  - 非リトライ対象エラー（404等）は即座に例外を再送出
- `get_existing_events()` の API 呼び出しを `_call_with_retry()` でラップ
- `upsert_event()` の insert/update 呼び出しを `_call_with_retry()` でラップ
- エラーメッセージを「API error after retries」に更新

## 確認方法

```bash
uv run pytest tests/test_sync.py::TestCallWithRetry -v
```

4件のテストがすべてパスすることを確認。

## エッジケース

- ページングが必要な場合、ページごとに独立してリトライされる（lambda でクロージャー化）
- `upsert_event` 内の既存イベント ID (`existing[eid]`) は lambda でキャプチャされるため、リトライ時も同じ値を使用
- 非 HTTP 例外（ネットワークエラー等）はリトライせず即再送出

Closes #35