### PR TITLE
fix: FMP APIキーをヘッダーからクエリパラメータに変更 (#39)

### DIFF
--- a/src/fetchers/fmp.py
+++ b/src/fetchers/fmp.py
@@ -56,13 +56,12 @@ class FMPFetcher(BaseFetcher):
             print("[fmp] FMP_API_KEY not set – skipping.")
             return []
 
-        url = f"{_FMP_BASE}?from={date_from}&to={date_to}"
+        url = f"{_FMP_BASE}?from={date_from}&to={date_to}&apikey={api_key}"
         try:
             req = urllib.request.Request(
                 url,
                 headers={
                     "Accept": "application/json",
-                    "apikey": api_key,
                 },
             )
             with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -652,6 +652,35 @@ class TestFMPFetcherNormalise:
         assert ids[0] == "fmp_USD_CPI_20260101T120000"
         assert ids[1] == "fmp_USD_CPI_20260101T120000_1"
 
+    def test_fetch_sends_apikey_as_query_param(self) -> None:
+        """API key must be passed as query parameter, not as a request header."""
+        from src.fetchers.fmp import FMPFetcher
+
+        captured_requests: list = []
+
+        def mock_urlopen(req, timeout=None):
+            captured_requests.append(req)
+            mock_response = MagicMock()
+            mock_response.read.return_value = b"[]"
+            mock_response.__enter__ = lambda s: s
+            mock_response.__exit__ = MagicMock(return_value=False)
+            return mock_response
+
+        with (
+            patch("urllib.request.urlopen", side_effect=mock_urlopen),
+            patch.dict("os.environ", {"FMP_API_KEY": "secret123"}),
+        ):
+            FMPFetcher().fetch("2026-01-01", "2026-01-07", countries={"USD"}, importance_min=1)
+
+        assert len(captured_requests) == 1
+        req = captured_requests[0]
+        assert "apikey=secret123" in req.full_url, (
+            f"API key should be in query params, got URL: {req.full_url}"
+        )
+        assert "apikey" not in (req.headers or {}), (
+            "API key should NOT be sent as a header"
+        )
+
 
 class TestEnvVarValidation:
     """Tests for explicit error messages when required env vars are missing."""


### PR DESCRIPTION
## 変更内容

FMP APIキーをHTTPヘッダー (`apikey:`) ではなく、クエリパラメータ (`?apikey=<key>`) として送信するよう修正。

FMP APIの仕様ではAPIキーはクエリパラメータで渡す必要があるため、ヘッダー経由では認証が通らず401エラーが発生していた。エラーは `except` でキャッチされ `[]` を返すためサイレントに失敗していた。

## 変更箇所

- `src/fetchers/fmp.py`: URLにAPIキーを追加し、ヘッダーから削除
- `tests/test_sync.py`: APIキーがクエリパラメータに含まれることを確認するテストを追加

## 確認方法

`FMP_API_KEY` を設定した環境で `EVENT_SOURCE=fmp` で実行し、イベントが正常に取得できることを確認。

## エッジケース

- APIキーが空の場合は既存の早期リターンで対処済み
- `urllib.request.Request` の `full_url` でクエリパラメータに正しく含まれることをテストで検証

Fixes #39