### PR TITLE
fix: イベント0件時に RuntimeError ではなく警告ログで正常終了 (#45)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -276,10 +276,11 @@ def main() -> None:
     print(f"Found {len(events)} matching events after filtering.")
 
     if not events:
-        raise RuntimeError(
-            "No events retrieved from the data source. "
-            "Check source connectivity and filters."
+        print(
+            "[sync] No events retrieved from the data source "
+            "(e.g. public holiday week or all filtered out). Skipping calendar update."
         )
+        return
 
     service = build_calendar_service()
     existing = get_existing_events(service, calendar_id, date_from, date_to)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -813,3 +813,32 @@ class TestCallWithRetry:
             _call_with_retry(not_found, max_retries=3)
 
         assert call_count == 1  # no retry
+
+
+class TestMainEmptyEvents:
+    """Tests for main() behavior when no events are retrieved."""
+
+    def test_main_returns_gracefully_when_no_events(self, capsys) -> None:
+        """main() should log a warning and return (not raise) when fetcher returns []."""
+        import os
+        from src.sync import main
+
+        env = {
+            "GOOGLE_CALENDAR_ID": "test@group.calendar.google.com",
+            "EVENT_SOURCE": "forexfactory",
+            "GOOGLE_SA_JSON": "{}",
+        }
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.name = "ForexFactory"
+        mock_fetcher.fetch.return_value = []
+
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("src.sync.get_fetcher", return_value=mock_fetcher),
+        ):
+            # Should NOT raise RuntimeError
+            main()
+
+        captured = capsys.readouterr()
+        assert "No events retrieved" in captured.out or "Skipping" in captured.out


### PR DESCRIPTION
## 概要

Issue #45 の修正。`main()` でフェッチ結果が空のとき `RuntimeError` を送出していたため、祝日週など正常ケースでも CI が失敗していた。

## 変更内容

- `src/sync.py`: `if not events` ブロックで `raise RuntimeError(...)` を `print()` + `return` に変更
- `tests/test_sync.py`: `TestMainEmptyEvents` クラスを追加し、0件時に例外なく正常終了することを確認

## 検証方法

```bash
uv run --extra dev python -m pytest tests/test_sync.py::TestMainEmptyEvents -v
```

## エッジケース

- 完全なネットワーク障害や認証エラーは引き続き例外を送出する（`get_fetcher` / `build_calendar_service` のエラーは変更なし）
- イベント0件はログに `[sync] No events retrieved...` と出力されるため、意図的なスキップと判別可能