### PR TITLE
fix: FMPFetcher が 429/5xx 時にリトライしない問題を修正 (#48)

### DIFF
--- a/src/fetchers/fmp.py
+++ b/src/fetchers/fmp.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 import os
+import time
+import urllib.error
 import urllib.request
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -16,6 +18,11 @@ from ..models import EconomicEvent
 from .base import BaseFetcher
 
 _FMP_BASE = "https://financialmodelingprep.com/api/v3/economic_calendar"
+
+# HTTP status codes worth retrying (rate-limit and transient server errors)
+_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+_MAX_RETRIES: int = 3
+_BACKOFF_BASE: float = 2.0
 
 # FMP uses 2-letter country codes; map to currency codes used by sync.py.
 _COUNTRY_TO_CCY: dict[str, str] = {
@@ -57,17 +64,10 @@ class FMPFetcher(BaseFetcher):
             return []
 
         url = f"{_FMP_BASE}?from={date_from}&to={date_to}&apikey={api_key}"
-        try:
-            req = urllib.request.Request(
-                url,
-                headers={
-                    "Accept": "application/json",
-                },
-            )
-            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-                data = json.loads(resp.read())
-        except Exception as exc:  # noqa: BLE001
-            print(f"[fmp] API request failed: {exc}")
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+
+        data = self._fetch_with_retry(req)
+        if data is None:
             return []
 
         if not isinstance(data, list):
@@ -101,6 +101,27 @@ class FMPFetcher(BaseFetcher):
     # ------------------------------------------------------------------ #
     # Helpers
     # ------------------------------------------------------------------ #
+
+    def _fetch_with_retry(self, req: urllib.request.Request) -> list | None:
+        """Execute an HTTP request with exponential back-off on 429/5xx errors.
+
+        Returns the parsed JSON list on success, or ``None`` on failure.
+        """
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                if exc.code not in _RETRYABLE_STATUS_CODES or attempt == _MAX_RETRIES:
+                    print(f"[fmp] API request failed: HTTP {exc.code}")
+                    return None
+                wait = _BACKOFF_BASE ** attempt
+                print(f"  [fmp retry] HTTP {exc.code}, waiting {wait:.0f}s (attempt {attempt + 1}/{_MAX_RETRIES})")
+                time.sleep(wait)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[fmp] API request failed: {exc}")
+                return None
+        return None  # unreachable but satisfies type checker
 
     @staticmethod
     def _parse_date(date_str: str) -> datetime | None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -842,3 +842,108 @@ class TestMainEmptyEvents:
 
         captured = capsys.readouterr()
         assert "No events retrieved" in captured.out or "Skipping" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# FMPFetcher retry tests
+# ---------------------------------------------------------------------------
+
+class TestFMPFetcherRetry:
+    """Tests for FMPFetcher._fetch_with_retry() exponential back-off."""
+
+    def test_success_on_first_attempt(self) -> None:
+        """Returns parsed JSON list when request succeeds immediately."""
+        from src.fetchers.fmp import FMPFetcher
+        import urllib.request
+        import io
+
+        fetcher = FMPFetcher()
+        payload = b'[{"event": "CPI", "country": "US"}]'
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = payload
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            req = urllib.request.Request("https://example.com")
+            result = fetcher._fetch_with_retry(req)
+
+        assert result == [{"event": "CPI", "country": "US"}]
+
+    def test_retries_on_429_then_succeeds(self, capsys) -> None:
+        """Retries on HTTP 429 and returns data on subsequent success."""
+        from src.fetchers.fmp import FMPFetcher
+        import urllib.error
+        import urllib.request
+
+        fetcher = FMPFetcher()
+        payload = b'[{"event": "NFP", "country": "US"}]'
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = payload
+
+        call_count = 0
+
+        def urlopen_side_effect(req, timeout):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError(None, 429, "Too Many Requests", {}, None)
+            return mock_resp
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            patch("time.sleep"),
+        ):
+            req = urllib.request.Request("https://example.com")
+            result = fetcher._fetch_with_retry(req)
+
+        assert result == [{"event": "NFP", "country": "US"}]
+        assert call_count == 2
+
+    def test_returns_none_after_all_retries_exhausted(self, capsys) -> None:
+        """Returns None when all retries fail with 429."""
+        from src.fetchers.fmp import FMPFetcher
+        import urllib.error
+        import urllib.request
+
+        fetcher = FMPFetcher()
+
+        def urlopen_side_effect(req, timeout):
+            raise urllib.error.HTTPError(None, 429, "Too Many Requests", {}, None)
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            patch("time.sleep"),
+        ):
+            req = urllib.request.Request("https://example.com")
+            result = fetcher._fetch_with_retry(req)
+
+        assert result is None
+
+    def test_non_retryable_http_error_returns_none_immediately(self, capsys) -> None:
+        """Returns None immediately on 401 without retrying."""
+        from src.fetchers.fmp import FMPFetcher
+        import urllib.error
+        import urllib.request
+
+        fetcher = FMPFetcher()
+        call_count = 0
+
+        def urlopen_side_effect(req, timeout):
+            nonlocal call_count
+            call_count += 1
+            raise urllib.error.HTTPError(None, 401, "Unauthorized", {}, None)
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            patch("time.sleep"),
+        ):
+            req = urllib.request.Request("https://example.com")
+            result = fetcher._fetch_with_retry(req)
+
+        assert result is None
+        assert call_count == 1  # no retry on 401


### PR DESCRIPTION
## 変更内容

Issue #48 の修正。`FMPFetcher.fetch()` が `urllib.request.urlopen` を直接呼び出しており、HTTP 429 や 5xx 系のエラー時にリトライしない問題を解消した。

### 実装詳細

- `_fetch_with_retry()` メソッドを新設し、`_call_with_retry()` (sync.py) と同様の指数バックオフロジックを実装
- リトライ対象: `429, 500, 502, 503, 504`
- 最大リトライ数: 3回、バックオフ係数: 2.0 (1s, 2s, 4s)
- 非リトライ対象の HTTP エラー（401, 403 等）は即座に `None` を返す
- `fetch()` が `None` を受け取った場合は空リストを返す（既存の挙動と同一）

### 確認方法

```bash
uv run python -m pytest tests/test_sync.py::TestFMPFetcherRetry -v
```

4 件のテストがすべて PASS することを確認済み。

### 考慮したエッジケース

- 全リトライ消耗後は `None` を返し、呼び出し元が空リストへフォールバックする
- 429 が続く場合はバックオフ待機してから次のリトライを実施
- `time.sleep` はテスト時にモック可能