### PR TITLE
fix: ForexFactoryFetcher が 429/5xx 時にリトライしない問題を修正 (#51)

### DIFF
--- a/src/fetchers/forexfactory.py
+++ b/src/fetchers/forexfactory.py
@@ -10,6 +10,8 @@ Uses two data sources in combination:
 from __future__ import annotations
 
 import json
+import time
+import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from datetime import datetime, timezone
@@ -18,6 +20,11 @@ from ..models import EconomicEvent
 from .base import BaseFetcher
 
 _FF_JSON_URL = "https://nfs.faireconomy.media/ff_calendar_thisweek.json"
+
+# HTTP status codes worth retrying (rate-limit and transient server errors)
+_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+_MAX_RETRIES: int = 3
+_BACKOFF_BASE: float = 2.0
 
 # FF impact strings → numeric levels
 _IMPACT_MAP: dict[str, int] = {
@@ -134,24 +141,46 @@ class ForexFactoryFetcher(BaseFetcher):
 
     @staticmethod
     def _fetch_ff_json() -> list[dict]:
-        """Download the official FF this-week JSON."""
-        try:
-            req = urllib.request.Request(
-                _FF_JSON_URL,
-                headers={
-                    "Accept": "application/json",
-                    "User-Agent": "Mozilla/5.0 (compatible; econ-cal-sync/0.1)",
-                },
-            )
-            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-                data = json.loads(resp.read())
-            if not isinstance(data, list):
-                return []
-            ForexFactoryFetcher._validate_ff_json_schema(data)
-            return data
-        except Exception as exc:  # noqa: BLE001
-            print(f"[forexfactory] FF JSON fetch failed: {exc}")
+        """Download the official FF this-week JSON with retry on 429/5xx."""
+        req = urllib.request.Request(
+            _FF_JSON_URL,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "Mozilla/5.0 (compatible; econ-cal-sync/0.1)",
+            },
+        )
+        data = ForexFactoryFetcher._fetch_with_retry(req)
+        if data is None:
             return []
+        if not isinstance(data, list):
+            return []
+        ForexFactoryFetcher._validate_ff_json_schema(data)
+        return data
+
+    @staticmethod
+    def _fetch_with_retry(req: urllib.request.Request) -> list | None:
+        """Execute an HTTP request with exponential back-off on 429/5xx errors.
+
+        Returns the parsed JSON list on success, or ``None`` on failure.
+        """
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                    return json.loads(resp.read())
+            except urllib.error.HTTPError as exc:
+                if exc.code not in _RETRYABLE_STATUS_CODES or attempt == _MAX_RETRIES:
+                    print(f"[forexfactory] FF JSON fetch failed: HTTP {exc.code}")
+                    return None
+                wait = _BACKOFF_BASE ** attempt
+                print(
+                    f"  [forexfactory retry] HTTP {exc.code}, "
+                    f"waiting {wait:.0f}s (attempt {attempt + 1}/{_MAX_RETRIES})"
+                )
+                time.sleep(wait)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[forexfactory] FF JSON fetch failed: {exc}")
+                return None
+        return None  # unreachable but satisfies type checker
 
     @staticmethod
     def _fetch_mct(date_from: str, date_to: str) -> list[dict]:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -947,3 +947,103 @@ class TestFMPFetcherRetry:
 
         assert result is None
         assert call_count == 1  # no retry on 401
+
+
+# ---------------------------------------------------------------------------
+# ForexFactoryFetcher retry tests
+# ---------------------------------------------------------------------------
+
+class TestForexFactoryFetcherRetry:
+    """Tests for ForexFactoryFetcher._fetch_with_retry() exponential back-off."""
+
+    def test_success_on_first_attempt(self) -> None:
+        """Returns parsed JSON list when request succeeds immediately."""
+        from src.fetchers.forexfactory import ForexFactoryFetcher
+        import urllib.request
+
+        payload = b'[{"title": "CPI", "country": "USD", "impact": "high", "date": "2026-03-08T08:30:00+00:00"}]'
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = payload
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            req = urllib.request.Request("https://example.com")
+            result = ForexFactoryFetcher._fetch_with_retry(req)
+
+        assert isinstance(result, list)
+        assert result[0]["title"] == "CPI"
+
+    def test_retries_on_429_then_succeeds(self) -> None:
+        """Retries on HTTP 429 and returns data on subsequent success."""
+        from src.fetchers.forexfactory import ForexFactoryFetcher
+        import urllib.error
+        import urllib.request
+
+        payload = b'[{"title": "NFP", "country": "USD", "impact": "high", "date": "2026-03-08T08:30:00+00:00"}]'
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = payload
+
+        call_count = 0
+
+        def urlopen_side_effect(req, timeout):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise urllib.error.HTTPError(None, 429, "Too Many Requests", {}, None)
+            return mock_resp
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            patch("time.sleep"),
+        ):
+            req = urllib.request.Request("https://example.com")
+            result = ForexFactoryFetcher._fetch_with_retry(req)
+
+        assert result is not None
+        assert call_count == 2
+
+    def test_returns_none_after_all_retries_exhausted(self) -> None:
+        """Returns None when all retries fail with 429."""
+        from src.fetchers.forexfactory import ForexFactoryFetcher
+        import urllib.error
+        import urllib.request
+
+        def urlopen_side_effect(req, timeout):
+            raise urllib.error.HTTPError(None, 429, "Too Many Requests", {}, None)
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            patch("time.sleep"),
+        ):
+            req = urllib.request.Request("https://example.com")
+            result = ForexFactoryFetcher._fetch_with_retry(req)
+
+        assert result is None
+
+    def test_non_retryable_http_error_returns_none_immediately(self) -> None:
+        """Returns None immediately on 401 without retrying."""
+        from src.fetchers.forexfactory import ForexFactoryFetcher
+        import urllib.error
+        import urllib.request
+
+        call_count = 0
+
+        def urlopen_side_effect(req, timeout):
+            nonlocal call_count
+            call_count += 1
+            raise urllib.error.HTTPError(None, 401, "Unauthorized", {}, None)
+
+        with (
+            patch("urllib.request.urlopen", side_effect=urlopen_side_effect),
+            patch("time.sleep"),
+        ):
+            req = urllib.request.Request("https://example.com")
+            result = ForexFactoryFetcher._fetch_with_retry(req)
+
+        assert result is None
+        assert call_count == 1  # no retry on 401


### PR DESCRIPTION
## 変更内容

Issue #51 の対応。`ForexFactoryFetcher._fetch_ff_json()` が HTTP 429 / 5xx を受け取った際にリトライせず即座に `[]` を返す問題を修正しました。

### 実装方針
- FMPFetcher (#50) と同様に `_fetch_with_retry()` 静的メソッドを追加
- リトライ対象: `{429, 500, 502, 503, 504}`
- 最大リトライ数: 3回
- バックオフ: 指数バックオフ (`2.0 ** attempt` 秒)
- 非リトライ対象 (401 等) は即座に `None` を返す

### 確認方法
```bash
uv run python -m pytest tests/test_sync.py -k "ForexFactory" -v
```

### エッジケース
- 全リトライ消費後は `None` を返し、`_fetch_ff_json()` が `[]` を返す（既存の graceful degradation を維持）
- 非リトライ HTTP エラー (401, 403 等) は即座に失敗
- ネットワーク例外 (`urllib.error.URLError` 等) は即座に失敗
- `_MCT_SCRAPE_TIMEOUT` による ThreadPoolExecutor のタイムアウトは変更なし