### PR TITLE
fix: failed イベントが存在しても RuntimeError を送出しないよう修正 (#56)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -301,8 +301,8 @@ def main() -> None:
 
     print(f"Done. Created: {created}, Updated: {updated}, Failed: {failed}")
     if failed:
-        raise RuntimeError(
-            f"{failed} event(s) could not be upserted. "
+        print(
+            f"[sync] WARNING: {failed} event(s) could not be upserted. "
             "Check the logs above for details."
         )
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1047,3 +1047,52 @@ class TestForexFactoryFetcherRetry:
 
         assert result is None
         assert call_count == 1  # no retry on 401
+
+
+# ---------------------------------------------------------------------------
+# Issue #56 — failed events should not raise RuntimeError
+# ---------------------------------------------------------------------------
+
+class TestMainFailedEventsNoRaise:
+    """Tests for main() behavior when some upsert_event calls return 'failed'."""
+
+    def test_main_does_not_raise_when_some_events_fail(self, capsys) -> None:
+        """main() should log a WARNING (not raise RuntimeError) when some events fail."""
+        from src.sync import main
+
+        env = {
+            "GOOGLE_CALENDAR_ID": "test@group.calendar.google.com",
+            "EVENT_SOURCE": "forexfactory",
+            "GOOGLE_SA_JSON": json.dumps({"type": "service_account"}),
+        }
+
+        sample_event = {
+            "title": "CPI",
+            "country": "US",
+            "impact": 3,
+            "dt": "2026-03-10T08:30:00+00:00",
+            "forecast": "0.3%",
+            "previous": "0.2%",
+            "source": "ff",
+        }
+
+        mock_fetcher = MagicMock()
+        mock_fetcher.name = "ForexFactory"
+        mock_fetcher.fetch.return_value = [sample_event]
+
+        mock_gcal_event = {"summary": "CPI", "start": {}, "end": {}}
+
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("src.sync.get_fetcher", return_value=mock_fetcher),
+            patch("src.sync.build_calendar_service", return_value=MagicMock()),
+            patch("src.sync.get_existing_events", return_value={}),
+            patch("src.sync.build_gcal_event", return_value=mock_gcal_event),
+            patch("src.sync.upsert_event", return_value="failed"),
+        ):
+            # Should NOT raise RuntimeError
+            main()
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "1" in captured.out


### PR DESCRIPTION
## 変更内容

`main()` 内で `upsert_event()` が `'failed'` を返したとき、`RuntimeError` を送出して GitHub Actions を失敗扱いにしていた問題を修正。

### 修正箇所

`src/sync.py` — `RuntimeError` を `print()` による WARNING ログに変更。

### なぜこれが問題か

- `upsert_event()` はすでに個別エラーをキャッチして `'failed'` を返す設計（例外を再送出しない）
- しかし `main()` で集計後に `RuntimeError` を送出していたため、1件でも失敗すると CI が常に `failure` になっていた
- 祝日週やレート制限など一時的な失敗でも毎回アラートが発生し、ノイズが大きかった

### 検証方法

1. `uv run python -m pytest tests/test_sync.py::TestMainFailedEventsNoRaise -v` → PASSED
2. `uv run python -m pytest tests/ -q` → 59 passed

### エッジケース

- 全件失敗した場合でも `RuntimeError` は送出しない（WARNING ログのみ）
- `created/updated/failed` のカウントは引き続きログに出力される

Closes #56