### PR TITLE
fix: get_existing_events() のページネーションループに上限を追加 (#55)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -168,6 +168,9 @@ def build_gcal_event(ev: EconomicEvent, owner_email: str | None = None) -> dict:
     return gcal
 
 
+_MAX_PAGINATION_PAGES = 50  # safety cap: 50 pages × 2500 events/page = 125,000 events
+
+
 def get_existing_events(
     service, calendar_id: str, date_from: str, date_to: str,
 ) -> dict[str, str]:
@@ -176,8 +179,15 @@ def get_existing_events(
     time_min = f"{date_from}T00:00:00Z"
     time_max = f"{date_to}T23:59:59Z"
     page_token = None
+    pages_fetched = 0
 
     while True:
+        if pages_fetched >= _MAX_PAGINATION_PAGES:
+            print(
+                f"[get_existing_events] WARNING: reached pagination limit "
+                f"({_MAX_PAGINATION_PAGES} pages). Stopping early."
+            )
+            break
         try:
             result = _call_with_retry(
                 lambda pt=page_token: service.events()
@@ -194,6 +204,7 @@ def get_existing_events(
             print(f"[get_existing_events] API error after retries: {exc}")
             break  # 取得済み分だけで続行（重複作成を最小限に抑える）
 
+        pages_fetched += 1
         for item in result.get("items", []):
             eid = (
                 item.get("extendedProperties", {})

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1096,3 +1096,57 @@ class TestMainFailedEventsNoRaise:
         captured = capsys.readouterr()
         assert "WARNING" in captured.out
         assert "1" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Issue #55 — get_existing_events() pagination should have a safety cap
+# ---------------------------------------------------------------------------
+
+class TestGetExistingEventsPaginationLimit:
+    """Tests for the MAX_PAGINATION_PAGES safety cap in get_existing_events()."""
+
+    def _make_page(self, n: int, has_next: bool) -> dict:
+        return {
+            "items": [
+                {
+                    "id": f"gcal-{n}-{i}",
+                    "extendedProperties": {"private": {"econ_event_id": f"eid-{n}-{i}"}},
+                }
+                for i in range(2)
+            ],
+            **({"nextPageToken": f"token-{n+1}"} if has_next else {}),
+        }
+
+    def test_stops_at_max_pages(self, capsys) -> None:
+        """get_existing_events() must stop and warn after MAX_PAGINATION_PAGES pages."""
+        from src.sync import get_existing_events, _MAX_PAGINATION_PAGES
+
+        call_count = 0
+
+        def fake_call(fn):
+            nonlocal call_count
+            call_count += 1
+            # Always return a page with nextPageToken so the loop would run forever
+            return {
+                "items": [
+                    {
+                        "id": f"gcal-{call_count}",
+                        "extendedProperties": {
+                            "private": {"econ_event_id": f"eid-{call_count}"}
+                        },
+                    }
+                ],
+                "nextPageToken": f"token-{call_count+1}",
+            }
+
+        with patch("src.sync._call_with_retry", side_effect=fake_call):
+            result = get_existing_events(
+                MagicMock(), "cal@example.com", "2026-01-01", "2026-12-31"
+            )
+
+        assert call_count == _MAX_PAGINATION_PAGES
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "pagination limit" in captured.out
+        # All fetched events should be present
+        assert len(result) == _MAX_PAGINATION_PAGES


### PR DESCRIPTION
## 概要

Issue #55 で指摘された、`get_existing_events()` のページネーションループに上限がない問題を修正します。

## 変更内容

- `_MAX_PAGINATION_PAGES = 50` 定数を追加（50ページ × 最大2500件 = 最大125,000件をカバー）
- `while True` ループの先頭でページ数チェックを行い、上限に達したら WARNING を出力してループを抜ける
- `pages_fetched` カウンターでフェッチ済みページ数を追跡

## 検証方法

```bash
uv run --with pytest python -m pytest tests/test_sync.py::TestGetExistingEventsPaginationLimit -v
```

## エッジケース

- 上限到達時は取得済みイベントで処理を継続（強制終了しない）
- 通常のカレンダー（数週間分）は上限に達しないため既存動作に影響なし
- 異常なほど大量のイベントが蓄積した場合のみ警告が出る

Closes #55