### PR TITLE
fix: attendees追加を削除してサービスアカウント403エラーを修正

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,4 +25,3 @@ jobs:
         env:
           GOOGLE_SA_JSON: ${{ secrets.GOOGLE_SA_JSON }}
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
-          CALENDAR_OWNER_EMAIL: ${{ secrets.CALENDAR_OWNER_EMAIL }}

--- a/src/sync.py
+++ b/src/sync.py
@@ -119,17 +119,8 @@ def _event_datetime(
     return start, end
 
 
-def build_gcal_event(ev: EconomicEvent, owner_email: str | None = None) -> dict:
-    """Convert a normalised :class:`EconomicEvent` to a Google Calendar event body.
-
-    Args:
-        ev: The economic event to convert.
-        owner_email: Optional calendar owner email address.  When provided, the
-            owner is added as an attendee so that Google Calendar delivers
-            reminders to their account (service-account-created events only
-            deliver reminders to the service account itself unless the owner is
-            explicitly listed as an attendee).
-    """
+def build_gcal_event(ev: EconomicEvent) -> dict:
+    """Convert a normalised :class:`EconomicEvent` to a Google Calendar event body."""
     flag = COUNTRY_FLAG.get(ev.country, "")
     stars = _IMPORTANCE_STARS.get(ev.importance, "")
     start, end = _event_datetime(ev, EVENT_DURATION_MINUTES)
@@ -158,12 +149,6 @@ def build_gcal_event(ev: EconomicEvent, owner_email: str | None = None) -> dict:
     color_id = _IMPORTANCE_COLOR.get(ev.importance)
     if color_id:
         gcal["colorId"] = color_id
-
-    # Add the calendar owner as an attendee so that Google Calendar delivers
-    # popup reminders to their account.  Without this, reminders only fire for
-    # the service account that created the event.
-    if owner_email:
-        gcal["attendees"] = [{"email": owner_email, "responseStatus": "accepted"}]
 
     return gcal
 
@@ -254,10 +239,6 @@ def main() -> None:
             "Set it to the target Google Calendar ID."
         )
     source_name = os.environ.get("EVENT_SOURCE", "forexfactory")
-    # Optional: calendar owner email for attendee-based reminder delivery.
-    # Service-account-created events only fire reminders for the service account
-    # unless the calendar owner is explicitly listed as an attendee.
-    owner_email = os.environ.get("CALENDAR_OWNER_EMAIL") or None
 
     fetcher = get_fetcher(source_name)
     print(f"Using data source: {fetcher.name}")
@@ -288,7 +269,7 @@ def main() -> None:
 
     created = updated = failed = 0
     for ev in events:
-        gcal_event = build_gcal_event(ev, owner_email=owner_email)
+        gcal_event = build_gcal_event(ev)
         action = upsert_event(service, calendar_id, gcal_event, existing)
         if action == "created":
             created += 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -315,7 +315,7 @@ class TestForexFactoryFetcherImportance:
 
 
 class TestReminders:
-    """Tests that Google Calendar events include popup reminders and optional attendee."""
+    """Tests that Google Calendar events include popup reminders."""
 
     def _make_ev(self) -> "EconomicEvent":
         return EconomicEvent(
@@ -342,30 +342,11 @@ class TestReminders:
         popup_minutes = {r["minutes"] for r in overrides if r["method"] == "popup"}
         assert popup_minutes == set(REMINDER_MINUTES)
 
-    def test_no_attendees_without_owner_email(self) -> None:
-        """Without owner_email, attendees should not be set."""
+    def test_no_attendees(self) -> None:
+        """Attendees must never be set (causes 403 with service accounts)."""
         from src.sync import build_gcal_event
         gcal = build_gcal_event(self._make_ev())
         assert "attendees" not in gcal
-
-    def test_attendee_added_with_owner_email(self) -> None:
-        """With owner_email, owner should appear as an accepted attendee."""
-        from src.sync import build_gcal_event
-        gcal = build_gcal_event(self._make_ev(), owner_email="owner@example.com")
-        assert "attendees" in gcal
-        assert gcal["attendees"][0]["email"] == "owner@example.com"
-        assert gcal["attendees"][0]["responseStatus"] == "accepted"
-
-    def test_reminders_still_present_with_owner_email(self) -> None:
-        """Popup reminders must be set even when owner_email is provided."""
-        from src.sync import build_gcal_event, REMINDER_MINUTES
-        gcal = build_gcal_event(self._make_ev(), owner_email="owner@example.com")
-        assert gcal["reminders"]["useDefault"] is False
-        popup_minutes = {
-            r["minutes"] for r in gcal["reminders"]["overrides"] if r["method"] == "popup"
-        }
-        assert popup_minutes == set(REMINDER_MINUTES)
-
 
 class TestUpsertEvent:
     """Tests for upsert_event error handling."""


### PR DESCRIPTION
## 問題

`CALENDAR_OWNER_EMAIL` を設定した状態で同期を実行すると全件 403 エラーで失敗する。

```
HttpError 403: Service accounts cannot invite attendees without Domain-Wide Delegation of Authority.
```

参照: https://github.com/eisei-komiya/econ-cal-sync/actions/runs/22831336032

## 原因

サービスアカウントが `attendees` フィールドを使ってユーザーを招待するには **Google Workspace の Domain-Wide Delegation** が必要。個人の Gmail では設定できない。

## 変更内容

- `src/sync.py`: `build_gcal_event()` から `owner_email` 引数・`attendees` 追加を削除。`main()` から `CALENDAR_OWNER_EMAIL` 環境変数の読み取りを削除
- `.github/workflows/sync.yml`: `CALENDAR_OWNER_EMAIL` secret を削除
- `tests/test_sync.py`: attendee関連テストを `test_no_attendees` に置き換え

## 確認

全57テスト通過

Fixes eisei-komiya/econ-cal-sync#63