### PR TITLE
fix: _call_with_retry() をネットワークエラー (socket.timeout / ConnectionError など) でリトライするよう修正 (#62)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -66,9 +66,26 @@ def _call_with_retry(request_callable, *, max_retries: int = _MAX_RETRIES) -> di
     ``request_callable`` must be a zero-argument callable that invokes
     ``<resource>.execute()`` and returns the response dict.
 
+    Retried on:
+    - :class:`googleapiclient.errors.HttpError` with status in
+      ``_RETRYABLE_STATUS_CODES`` (429, 500, 502, 503, 504)
+    - Network-level transient errors: :class:`socket.timeout`,
+      :class:`ConnectionError`, :class:`TimeoutError`, and
+      :class:`OSError` (covers ``BrokenPipeError``, ``ConnectionResetError``,
+      etc.).
+
     Raises the last exception when all retries are exhausted.
     """
+    import socket
+
     import googleapiclient.errors  # local import to keep top-level imports clean
+
+    _RETRYABLE_NETWORK_ERRORS = (
+        socket.timeout,
+        ConnectionError,   # base class for BrokenPipeError, ConnectionResetError, etc.
+        TimeoutError,      # built-in; raised by some HTTP clients on connect/read timeout
+        OSError,           # catches remaining low-level socket errors
+    )
 
     for attempt in range(max_retries + 1):
         try:
@@ -80,8 +97,15 @@ def _call_with_retry(request_callable, *, max_retries: int = _MAX_RETRIES) -> di
             wait = _BACKOFF_BASE ** attempt
             print(f"  [retry] HTTP {status}, waiting {wait:.0f}s (attempt {attempt + 1}/{max_retries})")
             time.sleep(wait)
-        except Exception:
-            raise  # non-HTTP errors are not retried
+        except _RETRYABLE_NETWORK_ERRORS as exc:
+            if attempt == max_retries:
+                raise
+            wait = _BACKOFF_BASE ** attempt
+            print(
+                f"  [retry] network error ({type(exc).__name__}: {exc}), "
+                f"waiting {wait:.0f}s (attempt {attempt + 1}/{max_retries})"
+            )
+            time.sleep(wait)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1131,3 +1131,87 @@ class TestGetExistingEventsPaginationLimit:
         assert "pagination limit" in captured.out
         # All fetched events should be present
         assert len(result) == _MAX_PAGINATION_PAGES
+
+
+# ---------------------------------------------------------------------------
+# Issue #62 — _call_with_retry() should retry on network-level errors
+# ---------------------------------------------------------------------------
+
+class TestCallWithRetryNetworkErrors:
+    """Tests that _call_with_retry() retries on socket/connection errors."""
+
+    def test_retries_on_socket_timeout(self) -> None:
+        """socket.timeout should be retried."""
+        import socket
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise socket.timeout("timed out")
+            return {"ok": True}
+
+        with patch("time.sleep"):
+            result = _call_with_retry(flaky, max_retries=4)
+
+        assert result == {"ok": True}
+        assert call_count == 3
+
+    def test_retries_on_connection_error(self) -> None:
+        """ConnectionError (and subclasses) should be retried."""
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ConnectionResetError("connection reset by peer")
+            return {"ok": True}
+
+        with patch("time.sleep"):
+            result = _call_with_retry(flaky, max_retries=3)
+
+        assert result == {"ok": True}
+        assert call_count == 2
+
+    def test_raises_after_max_retries_on_network_error(self) -> None:
+        """Should raise after exhausting retries on persistent network errors."""
+        import socket
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def always_fails():
+            nonlocal call_count
+            call_count += 1
+            raise socket.timeout("always times out")
+
+        with patch("time.sleep"):
+            with pytest.raises(socket.timeout):
+                _call_with_retry(always_fails, max_retries=2)
+
+        assert call_count == 3  # initial + 2 retries
+
+    def test_retries_on_timeout_error(self) -> None:
+        """Built-in TimeoutError should be retried."""
+        from src.sync import _call_with_retry
+
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise TimeoutError("request timed out")
+            return {"ok": True}
+
+        with patch("time.sleep"):
+            result = _call_with_retry(flaky, max_retries=3)
+
+        assert result == {"ok": True}
+        assert call_count == 2


### PR DESCRIPTION
## 変更内容

`_call_with_retry()` は従来 `HttpError` のみをリトライ対象としており、ネットワーク層のエラー（`socket.timeout`、`ConnectionError`、`TimeoutError`、`OSError`）はそのまま例外として送出していました。

ネットワーク環境の一時的な不安定（タイムアウト、接続リセットなど）でも同じ指数バックオフでリトライするよう修正しました。

## 変更点

- `_call_with_retry()` に `_RETRYABLE_NETWORK_ERRORS` タプルを追加
  - `socket.timeout`、`ConnectionError`（`BrokenPipeError`、`ConnectionResetError` などのベースクラス）、`TimeoutError`、`OSError` を対象
- ネットワークエラー時も `HttpError` と同じ指数バックオフでリトライ
- リトライログに例外の型名とメッセージを含める

## 確認方法

```bash
uv run python -m pytest tests/test_sync.py::TestCallWithRetryNetworkErrors -v
```

## エッジケース

- 最大リトライ回数到達後は元の例外をそのまま `raise`
- `OSError` はかなり広いため、将来的により狭い例外クラスへの絞り込みも検討可能
- `HttpError` のリトライ挙動には変更なし

Closes #62