### PR TITLE
fix: _fetch_with_retry() をネットワークエラー (socket.timeout / ConnectionError など) でリトライするよう修正 (#66)

### DIFF
--- a/src/fetchers/fmp.py
+++ b/src/fetchers/fmp.py
@@ -105,8 +105,25 @@ class FMPFetcher(BaseFetcher):
     def _fetch_with_retry(self, req: urllib.request.Request) -> list | None:
         """Execute an HTTP request with exponential back-off on 429/5xx errors.
 
+        Retried on:
+        - :class:`urllib.error.HTTPError` with status in
+          ``_RETRYABLE_STATUS_CODES`` (429, 500, 502, 503, 504)
+        - Network-level transient errors: :class:`socket.timeout`,
+          :class:`ConnectionError`, :class:`TimeoutError`, and
+          :class:`OSError` (covers ``BrokenPipeError``, ``ConnectionResetError``,
+          etc.).
+
         Returns the parsed JSON list on success, or ``None`` on failure.
         """
+        import socket
+
+        _RETRYABLE_NETWORK_ERRORS = (
+            socket.timeout,
+            ConnectionError,   # base class for BrokenPipeError, ConnectionResetError, etc.
+            TimeoutError,      # built-in; raised by some HTTP clients on connect/read timeout
+            OSError,           # catches remaining low-level socket errors
+        )
+
         for attempt in range(_MAX_RETRIES + 1):
             try:
                 with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
@@ -117,6 +134,16 @@ class FMPFetcher(BaseFetcher):
                     return None
                 wait = _BACKOFF_BASE ** attempt
                 print(f"  [fmp retry] HTTP {exc.code}, waiting {wait:.0f}s (attempt {attempt + 1}/{_MAX_RETRIES})")
+                time.sleep(wait)
+            except _RETRYABLE_NETWORK_ERRORS as exc:
+                if attempt == _MAX_RETRIES:
+                    print(f"[fmp] API request failed: {exc}")
+                    return None
+                wait = _BACKOFF_BASE ** attempt
+                print(
+                    f"  [fmp retry] network error ({type(exc).__name__}: {exc}), "
+                    f"waiting {wait:.0f}s (attempt {attempt + 1}/{_MAX_RETRIES})"
+                )
                 time.sleep(wait)
             except Exception as exc:  # noqa: BLE001
                 print(f"[fmp] API request failed: {exc}")

--- a/src/fetchers/forexfactory.py
+++ b/src/fetchers/forexfactory.py
@@ -161,8 +161,25 @@ class ForexFactoryFetcher(BaseFetcher):
     def _fetch_with_retry(req: urllib.request.Request) -> list | None:
         """Execute an HTTP request with exponential back-off on 429/5xx errors.
 
+        Retried on:
+        - :class:`urllib.error.HTTPError` with status in
+          ``_RETRYABLE_STATUS_CODES`` (429, 500, 502, 503, 504)
+        - Network-level transient errors: :class:`socket.timeout`,
+          :class:`ConnectionError`, :class:`TimeoutError`, and
+          :class:`OSError` (covers ``BrokenPipeError``, ``ConnectionResetError``,
+          etc.).
+
         Returns the parsed JSON list on success, or ``None`` on failure.
         """
+        import socket
+
+        _RETRYABLE_NETWORK_ERRORS = (
+            socket.timeout,
+            ConnectionError,   # base class for BrokenPipeError, ConnectionResetError, etc.
+            TimeoutError,      # built-in; raised by some HTTP clients on connect/read timeout
+            OSError,           # catches remaining low-level socket errors
+        )
+
         for attempt in range(_MAX_RETRIES + 1):
             try:
                 with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
@@ -174,6 +191,16 @@ class ForexFactoryFetcher(BaseFetcher):
                 wait = _BACKOFF_BASE ** attempt
                 print(
                     f"  [forexfactory retry] HTTP {exc.code}, "
+                    f"waiting {wait:.0f}s (attempt {attempt + 1}/{_MAX_RETRIES})"
+                )
+                time.sleep(wait)
+            except _RETRYABLE_NETWORK_ERRORS as exc:
+                if attempt == _MAX_RETRIES:
+                    print(f"[forexfactory] FF JSON fetch failed: {exc}")
+                    return None
+                wait = _BACKOFF_BASE ** attempt
+                print(
+                    f"  [forexfactory retry] network error ({type(exc).__name__}: {exc}), "
                     f"waiting {wait:.0f}s (attempt {attempt + 1}/{_MAX_RETRIES})"
                 )
                 time.sleep(wait)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1215,3 +1215,120 @@ class TestCallWithRetryNetworkErrors:
 
         assert result == {"ok": True}
         assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #66 — fmp._fetch_with_retry() / forexfactory._fetch_with_retry()
+#              should retry on network-level errors
+# ---------------------------------------------------------------------------
+
+class TestFmpFetchWithRetryNetworkErrors:
+    """Tests that FMPFetcher._fetch_with_retry() retries on socket/connection errors."""
+
+    def test_retries_on_socket_timeout(self) -> None:
+        import socket
+        from src.fetchers.fmp import FMPFetcher
+        import urllib.request
+
+        fetcher = FMPFetcher()
+        call_count = 0
+
+        original_urlopen = urllib.request.urlopen
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise socket.timeout("timed out")
+            import io
+            import json as _json
+
+            class FakeResp:
+                def read(self):
+                    return _json.dumps([]).encode()
+                def __enter__(self):
+                    return self
+                def __exit__(self, *a):
+                    pass
+
+            return FakeResp()
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch("time.sleep"):
+            req = urllib.request.Request("http://example.com")
+            result = fetcher._fetch_with_retry(req)
+
+        assert result == []
+        assert call_count == 3
+
+    def test_raises_none_after_max_retries(self) -> None:
+        import socket
+        from src.fetchers.fmp import FMPFetcher
+        import urllib.request
+
+        fetcher = FMPFetcher()
+        call_count = 0
+
+        def always_fails(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise socket.timeout("always times out")
+
+        with patch("urllib.request.urlopen", side_effect=always_fails), patch("time.sleep"):
+            req = urllib.request.Request("http://example.com")
+            result = fetcher._fetch_with_retry(req)
+
+        assert result is None
+        assert call_count == 4  # initial + 3 retries (_MAX_RETRIES=3)
+
+
+class TestForexFactoryFetchWithRetryNetworkErrors:
+    """Tests that ForexFactoryFetcher._fetch_with_retry() retries on socket/connection errors."""
+
+    def test_retries_on_connection_error(self) -> None:
+        from src.fetchers.forexfactory import ForexFactoryFetcher
+        import urllib.request
+
+        call_count = 0
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ConnectionResetError("connection reset by peer")
+            import json as _json
+
+            class FakeResp:
+                def read(self):
+                    return _json.dumps([]).encode()
+                def __enter__(self):
+                    return self
+                def __exit__(self, *a):
+                    pass
+
+            return FakeResp()
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), patch("time.sleep"):
+            req = urllib.request.Request("http://example.com")
+            result = ForexFactoryFetcher._fetch_with_retry(req)
+
+        assert result == []
+        assert call_count == 2
+
+    def test_returns_none_after_max_retries(self) -> None:
+        import socket
+        from src.fetchers.forexfactory import ForexFactoryFetcher
+        import urllib.request
+
+        call_count = 0
+
+        def always_fails(req, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise TimeoutError("always times out")
+
+        with patch("urllib.request.urlopen", side_effect=always_fails), patch("time.sleep"):
+            req = urllib.request.Request("http://example.com")
+            result = ForexFactoryFetcher._fetch_with_retry(req)
+
+        assert result is None
+        assert call_count == 4  # initial + 3 retries (_MAX_RETRIES=3)


### PR DESCRIPTION
## 変更内容

`fmp.py` と `forexfactory.py` の `_fetch_with_retry()` が、HTTPエラー以外のネットワークエラー（`socket.timeout`, `ConnectionError`, `TimeoutError`, `OSError` など）を `except Exception` でキャッチして即座に `None` を返していた問題を修正します。

## 根本原因 (Issue #66)

```python
# Before
except Exception as exc:  # noqa: BLE001
    print(f"[fmp] API request failed: {exc}")
    return None  # ← リトライせずに即 None を返す
```

ネットワーク障害はほとんど一時的なものですが、既存の実装ではリトライせずにフェッチを諦め、カレンダーが空になってしまいました。

## 修正内容

`_RETRYABLE_NETWORK_ERRORS` タプルを定義し、以下のエラーを `HttpError` と同様に指数バックオフでリトライするようにしました:

- `socket.timeout`
- `ConnectionError` (BrokenPipeError, ConnectionResetError などのベースクラス)
- `TimeoutError` (組み込み)
- `OSError` (その他の低レベルソケットエラー)

`fmp.py` および `forexfactory.py` の両方に同じ修正を適用しました（`sync.py` の `_call_with_retry()` に対して PR #65 で行ったものと同様のアプローチ）。

## 検証方法

```bash
uv run python -m pytest tests/test_sync.py::TestFmpFetchWithRetryNetworkErrors tests/test_sync.py::TestForexFactoryFetchWithRetryNetworkErrors -v
```

新規テスト4件がすべてパスすることを確認済み:
- `socket.timeout` 発生時にリトライすること
- `ConnectionError` 発生時にリトライすること
- リトライ上限後に `None` を返すこと

## エッジケース

- `OSError` が `ConnectionError` のスーパークラスでもあるため一部重複はありますが、動作には影響しません
- 既存の非ネットワーク例外 (`json.JSONDecodeError` など) は `except Exception` で引き続きキャッチされ、リトライなしで `None` を返します

Closes #66