### PR TITLE
fix: FMPFetcher._normalise() が importance を設定しない問題を修正 (#70)

### DIFF
--- a/src/fetchers/fmp.py
+++ b/src/fetchers/fmp.py
@@ -86,7 +86,7 @@ class FMPFetcher(BaseFetcher):
             dt = self._parse_date(raw.get("date") or "")
             if dt is None:
                 continue
-            event = self._normalise(raw, dt, ccy)
+            event = self._normalise(raw, dt, ccy, impact)
             base_id = event.id
             if base_id in seen_ids:
                 seen_ids[base_id] += 1
@@ -163,7 +163,7 @@ class FMPFetcher(BaseFetcher):
             return None
 
     @staticmethod
-    def _normalise(raw: dict, dt_utc: datetime, ccy: str) -> EconomicEvent:
+    def _normalise(raw: dict, dt_utc: datetime, ccy: str, importance: int = 0) -> EconomicEvent:
         event_name = (raw.get("event") or "Economic Event").strip()
         eid = f"fmp_{ccy}_{event_name}_{dt_utc.strftime('%Y%m%dT%H%M%S')}"
         return EconomicEvent(
@@ -176,4 +176,5 @@ class FMPFetcher(BaseFetcher):
             previous=str(raw.get("previous") or "N/A"),
             actual=str(raw.get("actual") or "N/A"),
             currency=ccy,
+            importance=importance,
         )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1332,3 +1332,66 @@ class TestForexFactoryFetchWithRetryNetworkErrors:
 
         assert result is None
         assert call_count == 4  # initial + 3 retries (_MAX_RETRIES=3)
+
+
+# ---------------------------------------------------------------------------
+# Issue #70 — FMPFetcher._normalise() should set importance field
+# ---------------------------------------------------------------------------
+
+class TestFmpNormaliseImportance:
+    """Tests that FMPFetcher._normalise() correctly sets the importance field."""
+
+    def test_importance_is_set_from_impact(self) -> None:
+        from datetime import datetime, timezone
+        from src.fetchers.fmp import FMPFetcher
+
+        dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        raw = {"event": "Non Farm Payrolls", "impact": "high"}
+
+        event = FMPFetcher._normalise(raw, dt, "USD", importance=3)
+
+        assert event.importance == 3
+
+    def test_importance_default_is_zero(self) -> None:
+        from datetime import datetime, timezone
+        from src.fetchers.fmp import FMPFetcher
+
+        dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        raw = {"event": "Some Event"}
+
+        event = FMPFetcher._normalise(raw, dt, "USD")
+
+        assert event.importance == 0
+
+    def test_fetch_propagates_importance_to_event(self) -> None:
+        """fetch() must pass the computed impact value through to _normalise()."""
+        import json
+        import os
+        from datetime import datetime, timezone
+        from src.fetchers.fmp import FMPFetcher
+        from unittest.mock import patch, MagicMock
+
+        fetcher = FMPFetcher()
+
+        fake_data = [
+            {
+                "event": "GDP",
+                "country": "US",
+                "impact": "high",
+                "date": "2025-01-15T12:00:00",
+                "estimate": "2.5%",
+                "previous": "2.0%",
+                "actual": "2.7%",
+            }
+        ]
+
+        with patch.object(fetcher, "_fetch_with_retry", return_value=fake_data), \
+             patch.dict(os.environ, {"FMP_API_KEY": "test_key"}):
+            events = fetcher.fetch(
+                "2025-01-15", "2025-01-15",
+                countries={"USD"},
+                importance_min=1,
+            )
+
+        assert len(events) == 1
+        assert events[0].importance == 3  # "high" → 3


### PR DESCRIPTION
## 変更内容

`FMPFetcher._normalise()` が `EconomicEvent.importance` フィールドを設定しておらず、常に `0` になっていた問題を修正しました（Issue #70）。

### 原因

`fetch()` メソッド内で `_IMPACT_MAP` から `impact` 値を計算していたにもかかわらず、`_normalise()` を呼び出す際にその値を渡していませんでした。

### 修正内容

- `_normalise()` に `importance: int = 0` パラメータを追加
- `fetch()` から `_normalise(raw, dt, ccy, impact)` として呼び出すよう修正
- 後方互換性のためデフォルト値は `0` のまま

### 確認方法

```bash
uv run python -m pytest tests/test_sync.py::TestFmpNormaliseImportance -v
```

### 追加テスト

- `_normalise()` に importance を渡すと正しく設定されること
- デフォルトは `0` のままであること
- `fetch()` が `impact` 値を `importance` としてイベントに伝搬すること

### エッジケース

- `impact` が `None` / 空文字の場合は `_IMPACT_MAP.get(...)` が `0` を返すため変更なし
- 既存の `importance_min` フィルタリングロジックは変更なし（フィルタリング後に `_normalise()` を呼ぶため問題なし）