### PR TITLE
fix: 無効な EVENT_SOURCE 環境変数で KeyError の代わりに RuntimeError を送出する (#69)

### DIFF
--- a/src/sync.py
+++ b/src/sync.py
@@ -275,7 +275,12 @@ def main() -> None:
         )
     source_name = os.environ.get("EVENT_SOURCE", "forexfactory")
 
-    fetcher = get_fetcher(source_name)
+    try:
+        fetcher = get_fetcher(source_name)
+    except KeyError as exc:
+        raise RuntimeError(
+            f"Invalid EVENT_SOURCE environment variable: {exc}"
+        ) from exc
     print(f"Using data source: {fetcher.name}")
 
     today = datetime.now(timezone.utc).date()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1395,3 +1395,43 @@ class TestFmpNormaliseImportance:
 
         assert len(events) == 1
         assert events[0].importance == 3  # "high" → 3
+
+
+# ---------------------------------------------------------------------------
+# Issue #69 — Invalid EVENT_SOURCE should raise RuntimeError, not KeyError
+# ---------------------------------------------------------------------------
+
+class TestInvalidEventSource:
+    """main() should raise RuntimeError (not KeyError) for unknown EVENT_SOURCE."""
+
+    def test_invalid_event_source_raises_runtime_error(self, monkeypatch) -> None:
+        import pytest
+        from src.sync import main
+        from unittest.mock import patch
+
+        monkeypatch.setenv("EVENT_SOURCE", "nonexistent_source")
+        monkeypatch.setenv("GOOGLE_SA_JSON", "{}")
+        monkeypatch.setenv("GOOGLE_CALENDAR_ID", "test@group.calendar.google.com")
+
+        with patch("src.sync.build_calendar_service"):
+            with pytest.raises(RuntimeError, match="Invalid EVENT_SOURCE"):
+                main()
+
+    def test_valid_event_source_does_not_raise(self, monkeypatch) -> None:
+        """forexfactory and fmp are valid sources and should not raise."""
+        from src.fetchers import get_fetcher
+
+        # Should not raise
+        fetcher = get_fetcher("forexfactory")
+        assert fetcher is not None
+
+        fetcher2 = get_fetcher("fmp")
+        assert fetcher2 is not None
+
+    def test_unknown_source_key_error_message(self) -> None:
+        """get_fetcher should include available sources in the error message."""
+        import pytest
+        from src.fetchers import get_fetcher
+
+        with pytest.raises(KeyError, match="forexfactory"):
+            get_fetcher("invalid_source")


### PR DESCRIPTION
## 変更内容

`sync.py` の `main()` で `get_fetcher()` が返す `KeyError` をキャッチし、ユーザーフレンドリーな `RuntimeError` にラップするようにした。

## 修正前の問題

無効な `EVENT_SOURCE` 環境変数（例: `EVENT_SOURCE=invalid`）を設定してツールを実行すると、スタックトレース付きの `KeyError: "Unknown fetcher ..."` が素通りしていた。エラーメッセージが `RuntimeError` ではなく `KeyError` として出力され、ユーザーには原因がわかりにくかった。

## 修正内容

- `src/sync.py`: `get_fetcher(source_name)` を `try/except KeyError` でラップし、`RuntimeError` に変換
- `tests/test_sync.py`: 以下の3テストを追加
  - 無効なソース名で `RuntimeError` が発生することを確認
  - 有効なソース名（`forexfactory`, `fmp`）では例外が発生しないことを確認
  - `get_fetcher` のエラーメッセージに利用可能なソース名が含まれることを確認

## 確認方法

```bash
uv run python -m pytest tests/test_sync.py -k TestInvalidEventSource -v
```

## エッジケース

- `get_fetcher()` はすでに `KeyError` で利用可能なソース名を含むメッセージを投げていたため、その情報を `RuntimeError` にそのまま引き継いでいる
- `EVENT_SOURCE` が未設定の場合はデフォルト `forexfactory` が使われるため影響なし

Fixes #69